### PR TITLE
Updates requirements.txt for PBR error and adds xsd:base64binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr>=0.6,!=0.7,<1.0
+pbr>=0.6,!=0.7,<2.0
 Babel>=1.3
 oslo.serialization
 webob

--- a/tools/wadl_to_swagger.py
+++ b/tools/wadl_to_swagger.py
@@ -72,6 +72,7 @@ TYPE_MAP = {
     'csapi:dict': 'object',
     'imageforcreate': 'string',
     'xsd:ip': 'string',
+    'xsd:base64binary': 'string',
 
     # TODO This array types also set the items
          # "tags": {


### PR DESCRIPTION
- Apparently the Images API has a xsd:base64binary data type for
  metadata properties.
