### PR TITLE
Removes schemes and securityDefinitions objects from Swagger output

### DIFF
--- a/fairy_slipper/cmd/wadl_to_swagger.py
+++ b/fairy_slipper/cmd/wadl_to_swagger.py
@@ -902,10 +902,8 @@ def main1(source_file, output_dir):
             }
         },
         u'paths': defaultdict(list),
-        u'schemes': [],
         u'tags': api_ref['tags'],
         u'basePath': "",
-        u'securityDefinitions': {},
         u'host': "",
         u'definitions': {},
         u'externalDocs': {


### PR DESCRIPTION
- Both those definitions are set by deployer.

Fixes Issue #50 and #49
